### PR TITLE
chore: add CLAUDE.md, project.md, and grooming artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ wheels/
 # Virtual environments
 .venv
 data/
-.env
+.env*
+!.env.example
 atreides.txt
 __pycache__/
 *.egg-info/

--- a/.groom/plan-2026-02-28.md
+++ b/.groom/plan-2026-02-28.md
@@ -1,0 +1,64 @@
+# Grooming Plan — 2026-02-28
+
+## Themes Explored
+
+- **A. Foundation Fixes**: Critical risk.py bug, bare exception handlers, settings validation, context manager
+- **B. Data Pipeline**: DuckDB schema, market snapshot poller, collect CLI command
+- **C. Volatility & Scoring**: Logit-space volatility estimation, composite market scoring, rank CLI
+- **D. Trading Readiness**: place_order/cancel_order behind read-only guard, dry-run mode
+- **E. Test Hardening**: CLI tests, error scenarios, position reconstruction edge cases
+
+## Directions Locked
+
+All five themes — Foundation fixes first, then data pipeline, then analytics and trading readiness in parallel, tests throughout.
+
+## Issues Created
+
+- #1: [P0] Fix RiskManager crash (score: ~85)
+- #2: [P1] Harden exchange adapter (score: ~80)
+- #3: [P1] Add Settings validation (score: ~80)
+- #4: [P1] DuckDB data store (score: ~85)
+- #5: [P1] Market snapshot poller + collect CLI (score: ~85)
+- #6: [P1] Logit-space volatility estimator (score: ~80)
+- #7: [P1] Market scoring + rank CLI (score: ~80)
+- #8: [P1] Implement place_order/cancel_order (score: ~80)
+- #9: [P1] Add dry-run trading mode (score: ~80)
+- #10: [P2] CLI + error scenario tests (score: ~75)
+- #11: [P2] Exchange adapter + position tests (score: ~75)
+
+## Execution Order
+
+```
+#1 (P0 bug) → #2 (harden adapter) → #3 (settings validation)
+                    ↓
+#4 (DuckDB store) → #5 (poller + collect)
+                    ↓
+#6 (volatility) → #7 (scoring + rank)
+                    ↓
+#8 (place_order) → #9 (dry-run)
+
+#10, #11 (tests) — in parallel throughout
+```
+
+## Deferred
+
+- **Orderbook depth snapshots**: Not needed for Phase 2 scoring. Revisit for Phase 4 A-S quoting.
+- **WebSocket streaming**: REST polling is sufficient at 30s intervals. Add when actively quoting.
+- **Jump-diffusion volatility (EM)**: Tier 3 sophistication. Start with rolling stddev + EWMA.
+- **Polymarket adapter**: Exchange abstraction ready. Add when waitlist clears.
+- **Graceful shutdown / cancel-all-on-exit**: Phase 3 when actually running unattended.
+- **Daily Parquet export**: Nice-to-have after data pipeline is running.
+
+## Research Findings
+
+### Key insight: Logit-space volatility
+Binary market prices bounded [0,1] break standard volatility estimation. The Oct 2025 arxiv paper "Toward Black-Scholes for Prediction Markets" provides the framework: transform to logit space, estimate sigma_b as diffusion coefficient of log-odds, use sigmoid to naturally compress spreads near boundaries.
+
+### Kalshi rate limits
+Basic tier: 20 reads/sec. Batch endpoints (`get_markets(limit=200)`) make polling efficient. 200 markets at 30s interval = 0.03 req/sec. WebSocket available for high-frequency data on actively quoted markets.
+
+### Reference bot gap
+No public bot implements logit-space volatility or A-S adapted for binary markets. All use volume ranking or LLM-based decisions. This is a genuine edge.
+
+### Risk module was broken
+`RiskManager.check_order()` references `Position.net_exposure` and `Position.avg_price` — neither exists. Tests passed only because they used empty position lists. Must fix before any trading work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+uv sync                          # install deps
+uv run pytest                    # all tests
+uv run pytest tests/test_models.py  # single file
+uv run ruff check src tests      # lint
+uv run ruff format src tests     # format
+python -m atreides markets       # list open markets (requires .env)
+python -m atreides balance       # portfolio + P&L
+python -m atreides book <ticker> # orderbook snapshot
+python -m atreides watch <ticker># stream price updates
+```
+
+## Architecture
+
+Prediction market trading bot. Phase 1 (done): read-only Kalshi integration. Phase 2 (active): data collection and volatility estimation. Phase 3: live trading with hard risk limits. Phase 4: Avellaneda-Stoikov market making.
+
+```
+src/atreides/
+  config.py         # pydantic-settings; env prefix ATREIDES_; singleton `settings`
+  models.py         # all domain types: Market, OrderBook, Position, OrderRequest, etc.
+  cli.py            # rich terminal UI; entry point via `python -m atreides`
+  exchange/
+    base.py         # Exchange Protocol (structural typing, runtime_checkable)
+    kalshi.py       # Kalshi adapter: SDK calls + raw HTTP fallback
+  strategy/
+    base.py         # Strategy Protocol (Phase 4 stub)
+  risk.py           # RiskManager: per-market limits, total exposure, daily loss, kill switch
+```
+
+**Exchange abstraction:** `exchange/base.py` defines a `Protocol`; all strategy/risk code uses that protocol, never importing from `exchange/kalshi.py` directly. New exchanges implement the same interface.
+
+**Kalshi adapter quirks:**
+- `get_positions()` SDK endpoint returns empty — positions are reconstructed from `get_fills()` + `get_settlements()`
+- Some markets have status values not in the SDK enum (e.g. `"finalized"`) — `get_market_safe()` falls back to raw HTTP
+- Orderbook bids are in `ob.var_true`, asks in `ob.var_false` (SDK naming artifact)
+
+**Price invariant:** Kalshi API sends prices in cents (1–99). Convert immediately with `_cents_to_dollars()`. Store and compute all prices as `Decimal`, never `float`.
+
+## Domain Glossary
+
+| Term | Definition |
+|------|-----------|
+| Binary market | Contract that pays $1 YES, $0 NO. Price = implied probability. |
+| yes_bid / yes_ask | Best bid/ask for the YES side. |
+| Mid | (bid + ask) / 2. Fair value estimate. |
+| Fill | A completed trade. Ground truth for position reconstruction. |
+| Settlement | Final market resolution. Revenue = payout for correct side. |
+
+## Key Patterns
+
+```python
+# Cents → dollars: always use this, never ad-hoc division
+def _cents_to_dollars(cents: int | float | None) -> Decimal:
+    if cents is None:
+        return Decimal("0")
+    return Decimal(str(cents)) / CENTS
+
+# SDK workaround: always provide raw fallback
+async def get_market_safe(self, market_id: str) -> Market | None:
+    try:
+        return await self.get_market(market_id)
+    except Exception:
+        pass
+    return await self._get_market_raw(market_id)
+```
+
+## Quality Bar
+
+- All exchange interactions go through the `Exchange` protocol — no SDK calls outside `kalshi.py`
+- Prices stored as `Decimal`, never `float`
+- Risk limits enforced before any order placement (Phase 3)
+- `tests/` uses mocked SDK — no live API calls in tests
+
+## Config
+
+`.env` with `ATREIDES_` prefix. Key vars:
+
+| Var | Default | Note |
+|-----|---------|------|
+| `ATREIDES_KALSHI_API_BASE` | demo URL | Change to prod URL for live trading |
+| `ATREIDES_KALSHI_KEY_ID` | `""` | RSA key ID from Kalshi dashboard |
+| `ATREIDES_KALSHI_PRIVATE_KEY_PATH` | `""` | Path to RSA private key file |
+| `ATREIDES_MAX_TOTAL_EXPOSURE` | `50` | Hard dollar cap across all positions |
+| `ATREIDES_MAX_DAILY_LOSS` | `20` | Triggers kill switch |
+
+Keys are production-only (demo endpoint returns 401 with real keys).

--- a/project.md
+++ b/project.md
@@ -1,0 +1,79 @@
+# Project: Atreides
+
+## Vision
+Prediction market trading bot that runs Avellaneda-Stoikov market making on Kalshi and Polymarket.
+
+**North Star:** Autonomous MM bot profitably quoting 10+ markets across exchanges, compounding returns.
+**Target User:** Solo trader (the developer) running the bot with real money.
+**Current Focus:** Phase 2 — data collection, volatility estimation, market opportunity scoring.
+**Key Differentiators:** Exchange-abstracted (same strategy runs anywhere), grounded in academic MM theory (A-S 2006), built incrementally with hard risk limits.
+
+## Domain Glossary
+
+| Term | Definition |
+|------|-----------|
+| Binary market | Contract that pays $1 if YES, $0 if NO. Price = implied probability. |
+| Yes bid / Yes ask | Best bid and ask prices for the YES side of a binary contract. |
+| Spread | Ask minus bid. Revenue opportunity for market makers. |
+| Mid | (Bid + Ask) / 2. Fair value estimate. |
+| Reservation price | A-S concept: inventory-adjusted fair value. Skews quotes away from risk. |
+| Fill | A completed trade. Kalshi records all fills with ticker, side, action, price, count. |
+| Settlement | Final resolution of a market. Revenue = payout for correct predictions. |
+| Cents vs dollars | Kalshi API uses cents (1-99). We convert to dollars (0.01-0.99) internally. |
+
+## Active Focus
+
+- **Milestone:** Phase 2 — Data Collection + Analytics
+- **Key Issues:** TBD (this grooming session)
+- **Theme:** Gather data, estimate volatility, identify MM opportunities before risking capital.
+
+## Quality Bar
+
+- [ ] All exchange interactions go through the Exchange protocol (no SDK calls outside adapter)
+- [ ] Prices stored as Decimal, never float
+- [ ] Risk limits enforced before any order placement
+- [ ] Tests cover model properties and exchange adapter logic
+- [ ] CLI commands work against live Kalshi production API
+
+## Patterns to Follow
+
+### Exchange adapter pattern
+```python
+# All exchange methods are async, return domain models (not SDK types)
+async def get_market(self, market_id: str) -> Market:
+    api = self._require_markets_api()
+    resp = api.get_markets(ticker=market_id)
+    return self._convert_market(resp.market)
+```
+
+### SDK workarounds
+```python
+# Kalshi SDK has gaps. Always provide a safe fallback.
+async def get_market_safe(self, market_id: str) -> Market | None:
+    try:
+        return await self.get_market(market_id)
+    except Exception:
+        pass
+    return await self._get_market_raw(market_id)
+```
+
+### Cents-to-dollars conversion
+```python
+CENTS = Decimal("100")
+def _cents_to_dollars(cents: int | float | None) -> Decimal:
+    if cents is None:
+        return Decimal("0")
+    return Decimal(str(cents)) / CENTS
+```
+
+## Lessons Learned
+
+| Decision | Outcome | Lesson |
+|----------|---------|--------|
+| Trust `get_positions()` SDK endpoint | Returns empty for real accounts | Reconstruct from `get_fills()` + `get_settlements()` |
+| Trust SDK Market model validation | Rejects "finalized" status enum | Need raw API fallback for any SDK model parse |
+| Use demo API for initial testing | 401 — keys are production-only | User's keys are prod; test read-only ops first |
+
+---
+*Last updated: 2026-02-27*
+*Updated during: /groom session*


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: Claude Code guidance — commands, architecture, Kalshi adapter quirks, key patterns, config reference
- `project.md`: Product vision, domain glossary, quality bar, lessons learned
- `.groom/plan-2026-02-28.md`: Sprint planning artifacts from /groom session

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
* Updated environment file configuration management in project setup
* Added comprehensive developer guide documenting setup, testing, and system architecture
* Added project documentation defining vision and design patterns
* Added grooming plan with exploration themes and execution roadmap

<!-- end of auto-generated comment: release notes by coderabbit.ai -->